### PR TITLE
Fix typo updating query string params

### DIFF
--- a/app/code/community/SomethingDigital/PageCacheParams/Model/Processor.php
+++ b/app/code/community/SomethingDigital/PageCacheParams/Model/Processor.php
@@ -101,7 +101,7 @@ class SomethingDigital_PageCacheParams_Model_Processor
 
         // Changed, recombine.
         if ($changed) {
-            $query = implode('&', $query);
+            $query = implode('&', $params);
         }
         return $changed;
     }


### PR DESCRIPTION
This was causing params in query string vars to be erased.