### PR TITLE
Release v1.0.2

### DIFF
--- a/app/code/community/SomethingDigital/PageCacheParams/etc/config.xml
+++ b/app/code/community/SomethingDigital/PageCacheParams/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <SomethingDigital_PageCacheParams>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </SomethingDigital_PageCacheParams>
     </modules>
 

--- a/app/etc/10_sd_pagecacheparams.xml
+++ b/app/etc/10_sd_pagecacheparams.xml
@@ -17,6 +17,10 @@
                 <utm_medium />
                 <utm_source />
                 <_ga />
+                
+                <!-- Mailchimp -->
+                <mc_cid />
+                <mc_eid />
             </blacklist>
         </sd_pagecacheparams>
     </global>

--- a/app/etc/10_sd_pagecacheparams.xml
+++ b/app/etc/10_sd_pagecacheparams.xml
@@ -17,10 +17,18 @@
                 <utm_medium />
                 <utm_source />
                 <_ga />
+                <gclsrc />
                 
                 <!-- Mailchimp -->
                 <mc_cid />
                 <mc_eid />
+
+                <!-- Bronto -->
+                <_bta_tid />
+
+                <!-- GoDataFeed -->
+                <gdfms />
+                <gdffi />
             </blacklist>
         </sd_pagecacheparams>
     </global>


### PR DESCRIPTION
 * Additional default parameters, for Bronto, Mailchimp, GoDataFeed, and DoubleClick.